### PR TITLE
Allow killing of messages we can't parse.

### DIFF
--- a/awsmsg/sqs_parse.go
+++ b/awsmsg/sqs_parse.go
@@ -48,7 +48,6 @@ var SQSMessageAttributes = []string{
 }
 
 func ParseSQSMessage(msg types.Message) (*messaging_pb.Message, error) {
-
 	serviceNameAttributeValue, ok := msg.MessageAttributes[serviceAttribute]
 	if ok && serviceNameAttributeValue.StringValue != nil {
 		return parseServiceMessage(msg, *serviceNameAttributeValue.StringValue)


### PR DESCRIPTION
We're seeing the situation where messages failing the parse step are never killed. This fixes it.